### PR TITLE
Fix Play errors and upgrade to 2.4

### DIFF
--- a/play/benchmarker/activator-sbt-echo-akka-shim.sbt
+++ b/play/benchmarker/activator-sbt-echo-akka-shim.sbt
@@ -1,1 +1,0 @@
-echoSettings

--- a/play/benchmarker/app/controllers/Application.scala
+++ b/play/benchmarker/app/controllers/Application.scala
@@ -2,11 +2,16 @@ package controllers
 
 import play.api._
 import play.api.mvc._
+import models._
 
-object Application extends Controller {
+class Application extends Controller {
 
   def index(title: String) = Action {
-     val members = List(Map("name" -> "Chris McCord"), Map("name" -> "Matt Sears"), Map("name" -> "David Stump"), Map("name" -> "Ricardo Thompson"))
-    Ok(views.html.index(members, title))
+     Ok(views.html.index(Seq(
+       Member("Chris McCord"),
+       Member("Matt Sears"),
+       Member("David Stump"),
+       Member("Ricardo Thompson")
+    ), title))
   }
 }

--- a/play/benchmarker/app/models/Member.scala
+++ b/play/benchmarker/app/models/Member.scala
@@ -1,0 +1,3 @@
+package models
+
+case class Member(name: String)

--- a/play/benchmarker/app/views/bio.scala.html
+++ b/play/benchmarker/app/views/bio.scala.html
@@ -1,3 +1,3 @@
-@(memberName: String)
+@(member: Member)
 
-<b>Name:</b> @memberName
+<b>Name:</b> @member.name

--- a/play/benchmarker/app/views/index.scala.html
+++ b/play/benchmarker/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(members: List[Map[String, String]], title: String)
+@(members: Seq[Member], title: String)
 
 @main {
   <div class="jumbotron">
@@ -30,7 +30,7 @@
       <ul>
         @for(member <- members) {
           <li>
-            @bio(member.get("name").get)
+            @bio(member)
           </li>
         }
       </ul>

--- a/play/benchmarker/build.sbt
+++ b/play/benchmarker/build.sbt
@@ -1,14 +1,7 @@
 name := """play-scala"""
-
 version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.11.1"
-
-libraryDependencies ++= Seq(
-  jdbc,
-  anorm,
-  cache,
-  ws
-)
+scalaVersion := "2.11.7"
+routesGenerator := InjectedRoutesGenerator

--- a/play/benchmarker/conf/application.conf
+++ b/play/benchmarker/conf/application.conf
@@ -1,62 +1,20 @@
 # This is the main configuration file for the application.
 # ~~~~~
 
-# Secret key
-# ~~~~~
-# The secret key is used to secure cryptographics functions.
-#
-# This must be changed for production, but we recommend not changing it in this file.
-#
-# See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="5131Gn@V8_gZn9Sp@<Y^DlP/91Icj<N0_N]UGwb`^y6^NI/Y4@6o:_kSqm7LuNd8"
+play {
+  
+  crypto.secret = "5131Gn@V8_gZn9Sp@<Y^DlP/91Icj<N0_N]UGwb`^y6^NI/Y4@6o:_kSqm7LuNd8"
+  
+  i18n.langs = ["en"]
 
-# The application languages
-# ~~~~~
-application.langs="en"
+  # This config isn't technically necessary, but disables Play's support for backwards
+  # compatibility with GlobalSettings, making things slightly faster.
+  http {
+    requestHandler = "play.api.http.DefaultHttpRequestHandler"
+    errorHandler = "play.api.http.DefaultHttpErrorHandler"
+    filters = "play.api.http.NoHttpFilters"
+  }
 
-# Global object class
-# ~~~~~
-# Define the Global object class for this application.
-# Default to Global in the root package.
-# application.global=Global
-
-# Router
-# ~~~~~
-# Define the Router object to use for this application.
-# This router will be looked up first when the application is starting up,
-# so make sure this is the entry point.
-# Furthermore, it's assumed your route file is named properly.
-# So for an application router like `my.application.Router`,
-# you may need to define a router file `conf/my.application.routes`.
-# Default to Routes in the root package (and conf/routes)
-# application.router=my.application.Routes
-
-# Database configuration
-# ~~~~~
-# You can declare as many datasources as you want.
-# By convention, the default datasource is named `default`
-#
-# db.default.driver=org.h2.Driver
-# db.default.url="jdbc:h2:mem:play"
-# db.default.user=sa
-# db.default.password=""
-
-# Evolutions
-# ~~~~~
-# You can disable evolutions if needed
-# evolutionplugin=disabled
-
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/),
-# by providing an application-logger.xml file in the conf directory.
-
-# Root logger:
-logger.root=ERROR
-
-# Logger used by the framework:
-logger.play=INFO
-
-# Logger provided to your application:
-logger.application=DEBUG
-
+  # This is needed to work around issues on OSX where under load, kqueue rejects connections.
+  server.netty.option.backlog = 1024
+}

--- a/play/benchmarker/project/activator-sbt-echo-shim.sbt
+++ b/play/benchmarker/project/activator-sbt-echo-shim.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-echo" % "0.1.6.2")

--- a/play/benchmarker/project/activator-sbt-eclipse-shim.sbt
+++ b/play/benchmarker/project/activator-sbt-eclipse-shim.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")

--- a/play/benchmarker/project/activator-sbt-idea-shim.sbt
+++ b/play/benchmarker/project/activator-sbt-idea-shim.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")

--- a/play/benchmarker/project/build.properties
+++ b/play/benchmarker/project/build.properties
@@ -1,4 +1,1 @@
-#Activator-generated Properties
-#Fri Jan 16 18:54:40 CST 2015
-template.uuid=59b33e52-e2cf-4bb9-9028-4e0fce1b8ea7
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/play/benchmarker/project/plugins.sbt
+++ b/play/benchmarker/project/plugins.sbt
@@ -1,18 +1,4 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.7")
-
-// web plugins
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-jshint" % "1.0.1")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.1")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.0.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.0.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")

--- a/play/benchmarker/public/javascripts/hello.js
+++ b/play/benchmarker/public/javascripts/hello.js
@@ -1,3 +1,0 @@
-if (window.console) {
-  console.log("Welcome to your Play application's JavaScript!");
-}


### PR DESCRIPTION
* Fixed the Play errors, they only occur on OSX, and the problem is described [here](http://www.ybrikman.com/writing/2014/02/18/maxing-out-at-50-concurrent-connections/)
* Upgraded to Play 2.4.2. Play 2.4 is slightly faster than 2.3, around 5%.
* Removed unnecessary libraries/plugins/activator shims - these won't affect the benchmark, but do change how much needs to be downloaded to run the Play app.
* Reworked the app a little bit to represent a more idiomatic Play application, eg use case classes instead of maps for the members.  Technically this actually will make the Play app slightly faster, since creating an ordinary object is faster than creating a Map, but the actual impact would be less than a microsecond per request.