### PR TITLE
Install gem bundler before bundle install

### DIFF
--- a/bootstrap_darwin.sh
+++ b/bootstrap_darwin.sh
@@ -13,9 +13,11 @@ fi
 # bootstrap rails/sinatra
 brew install rbenv
 rbenv install --skip-existing 2.2.0
+rbenv shell 2.2.0 && gem install bundler
+rbenv shell --unset
 (cd rails/benchmarker   && bundle install)
 (cd sinatra/benchmarker && bundle install)
-(cd cuba/benchmarker && bundle install)
+(cd cuba/benchmarker    && bundle install)
 
 # bootstrap express
 brew install node


### PR DESCRIPTION
Before you can run `bundle install` for a new version of ruby on a system, you need to install bundler.