### PR TITLE
Remove get_flash

### DIFF
--- a/phoenix/benchmarker/web/templates/layout/app.html.eex
+++ b/phoenix/benchmarker/web/templates/layout/app.html.eex
@@ -22,9 +22,6 @@
         <span class="logo"></span>
       </header>
 
-      <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
-      <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
-
       <main role="main">
         <%= render @view_module, @view_template, assigns %>
       </main>


### PR DESCRIPTION
I've just noticed, `<%= get_flash %>` should also be removed since `fetch_flash` plug is no longer used. Otherwise it would result in `flash not fetched, call fetch_flash/2` error. Sorry for that.